### PR TITLE
Add multierror package for representing slices of error values as a single error.

### DIFF
--- a/event/reader.go
+++ b/event/reader.go
@@ -60,7 +60,8 @@ func (r *Reader) Read(ctx context.Context, fn Handler) error {
 
 // Close the connection to the event stream.
 func (r *Reader) Close() error {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	const timeout = time.Second * 10
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	return r.subscription.Shutdown(ctx)
 }

--- a/event/writer.go
+++ b/event/writer.go
@@ -51,7 +51,8 @@ func (w *Writer) Write(ctx context.Context, evt Event) error {
 
 // Close the connection to the event stream.
 func (w *Writer) Close() error {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	const timeout = time.Second * 10
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	return w.topic.Shutdown(ctx)
 }

--- a/multierror/error.go
+++ b/multierror/error.go
@@ -1,0 +1,74 @@
+// Package multierror provides a mechanism for representing a list of error values as a single error.
+package multierror
+
+import (
+	"errors"
+	"strings"
+)
+
+type (
+	multiError []error
+)
+
+// Append zero or more errors to a single error. Returns nil if the resulting
+// slice would be empty.
+func Append(err error, errs ...error) error {
+	switch e := err.(type) {
+	case multiError:
+		return append(e, errs...)
+	default:
+		sl := make([]error, 0)
+		if e != nil {
+			sl = append(sl, e)
+		}
+
+		for _, e = range errs {
+			if e == nil {
+				continue
+			}
+
+			sl = append(sl, e)
+		}
+
+		if len(sl) == 0 {
+			return nil
+		}
+
+		return multiError(sl)
+	}
+}
+
+// Error returns a string containing all appended errors separated by semicolons.
+func (e multiError) Error() string {
+	arr := make([]string, len(e))
+	for i, err := range e {
+		arr[i] = err.Error()
+	}
+
+	return strings.Join(arr, "; ")
+}
+
+// Is reports whether any error in the collection whose chain matches target. Returns true on
+// the first match.
+func (e multiError) Is(target error) bool {
+	for _, err := range e {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// As finds the first error in the collection whose chain that matches target, and if so, sets
+// target to that error value and returns true. Otherwise, it returns false. Returns true on
+// the first match.
+func (e multiError) As(target interface{}) bool {
+	for _, err := range e {
+		if errors.As(err, target) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/multierror/error_test.go
+++ b/multierror/error_test.go
@@ -1,0 +1,43 @@
+package multierror_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"pkg.dsb.dev/multierror"
+)
+
+func TestAppend(t *testing.T) {
+	t.Parallel()
+
+	// If we pass in nil, we get nil back.
+	multiErr := multierror.Append(nil, nil, nil)
+	assert.Nil(t, multiErr)
+
+	first := errors.New("first")
+	second := errors.New("second")
+	third := errors.New("third")
+
+	// Create an error with the first two errors.
+	multiErr = multierror.Append(first, second)
+
+	// Assert the error equals the first and second
+	assert.True(t, errors.Is(multiErr, first))
+	assert.True(t, errors.Is(multiErr, second))
+	assert.Equal(t, "first; second", multiErr.Error())
+
+	// Add a third error
+	multiErr = multierror.Append(multiErr, third)
+
+	// Assert we still equal all other errors.
+	assert.True(t, errors.Is(multiErr, first))
+	assert.True(t, errors.Is(multiErr, second))
+	assert.True(t, errors.Is(multiErr, third))
+	assert.Equal(t, "first; second; third", multiErr.Error())
+
+	// Assert we don't equal some other random error
+	fourth := errors.New("fourth")
+	assert.False(t, errors.Is(multiErr, fourth))
+}


### PR DESCRIPTION
Also sets some constants for timeouts in event package to make linting happy.