### PR TITLE
Add support for SQL database migrations

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -167,7 +167,6 @@ github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
-github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -375,7 +374,6 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -567,13 +565,11 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
@@ -1143,7 +1139,6 @@ golang.org/x/tools v0.0.0-20200701041122-1837592efa10/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200713011307-fd294ab11aed/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200717024301-6ddee64345a6/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200724022722-7017fd6b1305/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
-golang.org/x/tools v0.0.0-20200725200936-102e7d357031 h1:VtIxiVHWPhnny2ZTi4f9/2diZKqyLaq3FUTuud5+khA=
 golang.org/x/tools v0.0.0-20200725200936-102e7d357031/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200731060945-b5fad4ed8dd6/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200812195022-5ae4c3c160a0 h1:SQvH+DjrwqD1hyyQU+K7JegHz1KEZgEwt17p9d6R2eg=
@@ -1152,7 +1147,6 @@ golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1247,7 +1241,6 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/storage/database/helpers.go
+++ b/storage/database/helpers.go
@@ -1,5 +1,5 @@
-// Package storage contains utilities for persistence methods used by the application.
-package storage
+// Package database contains utilities for interacting with databases.
+package database
 
 import (
 	"time"

--- a/storage/database/helpers_test.go
+++ b/storage/database/helpers_test.go
@@ -1,4 +1,4 @@
-package storage_test
+package database_test
 
 import (
 	"testing"
@@ -6,15 +6,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"pkg.dsb.dev/storage"
+	"pkg.dsb.dev/storage/database"
 )
 
 func TestFromInterval(t *testing.T) {
 	t.Parallel()
 
 	exp := time.Hour
-	itv := storage.ToInterval(exp)
-	act := storage.FromInterval(itv)
+	itv := database.ToInterval(exp)
+	act := database.FromInterval(itv)
 
 	assert.Equal(t, exp, act)
 }
@@ -23,8 +23,8 @@ func TestFromTextArray(t *testing.T) {
 	t.Parallel()
 
 	exp := []string{"a", "b", "c"}
-	arr := storage.ToTextArray(exp)
-	act := storage.FromTextArray(arr)
+	arr := database.ToTextArray(exp)
+	act := database.FromTextArray(arr)
 
 	assert.EqualValues(t, exp, act)
 }

--- a/storage/database/migrate.go
+++ b/storage/database/migrate.go
@@ -1,0 +1,125 @@
+package database
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/golang-migrate/migrate/v4"
+	"github.com/golang-migrate/migrate/v4/database"
+	"github.com/golang-migrate/migrate/v4/source"
+
+	// Driver for file based migrations.
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+
+	// Driver for bindata migrations.
+	bindata "github.com/golang-migrate/migrate/v4/source/go_bindata"
+)
+
+// ErrNotADirectory is returned if attempting to migrate without a valid directory.
+var ErrNotADirectory = errors.New("invalid migration directory")
+
+// The MigrationSource type is used as a source of migration info for performing migration actions
+// against a database.
+type MigrationSource struct {
+	name           string
+	sourceDriver   func() (source.Driver, error)
+	databaseDriver func(db *sql.DB) (database.Driver, error)
+}
+
+// Migrate performs the migration action given a source driver.
+func Migrate(action func(*migrate.Migrate) error, source *MigrationSource, db *sql.DB) error {
+	dbDriver, err := source.databaseDriver(db)
+	if err != nil {
+		return err
+	}
+
+	d, err := source.sourceDriver()
+	if err != nil {
+		return err
+	}
+
+	m, err := migrate.NewWithInstance(source.name, d, "", dbDriver)
+	if err != nil {
+		return err
+	}
+
+	err = action(m)
+	switch {
+	case errors.Is(err, migrate.ErrNoChange):
+		return nil
+	case err != nil:
+		return fmt.Errorf("could not perform migration: %w", err)
+	default:
+		return nil
+	}
+}
+
+// MigrateUp applies all migrations from the migration source that haven't been applied yet.
+func MigrateUp(s *MigrationSource, db *sql.DB) error {
+	action := func(m *migrate.Migrate) error { return m.Up() }
+
+	return Migrate(action, s, db)
+}
+
+// MigrateDown reverts all migrations from the migration source that have already been applied.
+func MigrateDown(s *MigrationSource, db *sql.DB) error {
+	action := func(m *migrate.Migrate) error { return m.Down() }
+
+	return Migrate(action, s, db)
+}
+
+// NewDirectoryMigration creates a migration from the provided directory path.
+// The parameter must be a directory.
+func NewDirectoryMigration(dbDriver func(db *sql.DB) (database.Driver, error), dir string) *MigrationSource {
+	return &MigrationSource{
+		name: "migration-dir",
+		sourceDriver: func() (source.Driver, error) {
+			ok, err := isDirectory(dir)
+			if err != nil {
+				return nil, err
+			}
+
+			if !ok {
+				return nil, ErrNotADirectory
+			}
+
+			return source.Open(pathToFileURL(dir))
+		},
+		databaseDriver: dbDriver,
+	}
+}
+
+// NewBindataMigration creates a migration from the provided bindata asset.
+func NewBindataMigration(dbDriver func(db *sql.DB) (database.Driver, error), b *bindata.AssetSource) *MigrationSource {
+	return &MigrationSource{
+		name: "bindata",
+		sourceDriver: func() (source.Driver, error) {
+			return bindata.WithInstance(b)
+		},
+		databaseDriver: dbDriver,
+	}
+}
+
+func isDirectory(name string) (bool, error) {
+	info, err := os.Stat(name)
+	if err != nil {
+		return false, err
+	}
+
+	return info.IsDir(), nil
+}
+
+func pathToFileURL(path string) string {
+	if !filepath.IsAbs(path) {
+		var err error
+		path, err = filepath.Abs(path)
+		if err != nil {
+			return ""
+		}
+	}
+
+	return fmt.Sprintf("file://%s", filepath.ToSlash(path))
+}

--- a/storage/database/postgres/migrate.go
+++ b/storage/database/postgres/migrate.go
@@ -1,0 +1,26 @@
+package postgres
+
+import (
+	"database/sql"
+
+	"github.com/golang-migrate/migrate/v4/database"
+	"github.com/golang-migrate/migrate/v4/database/postgres"
+	bindata "github.com/golang-migrate/migrate/v4/source/go_bindata"
+
+	pkgdb "pkg.dsb.dev/storage/database"
+)
+
+// NewDirectoryMigration creates a migration from the provided directory path.
+// The parameter must be a directory.
+func NewDirectoryMigration(dir string) *pkgdb.MigrationSource {
+	return pkgdb.NewDirectoryMigration(newPostgresDBDriver, dir)
+}
+
+// NewBindataMigration creates a migration from the provided bindata asset.
+func NewBindataMigration(b *bindata.AssetSource) *pkgdb.MigrationSource {
+	return pkgdb.NewBindataMigration(newPostgresDBDriver, b)
+}
+
+func newPostgresDBDriver(db *sql.DB) (database.Driver, error) {
+	return postgres.WithInstance(db, new(postgres.Config))
+}

--- a/storage/database/postgres/sql_test.go
+++ b/storage/database/postgres/sql_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"pkg.dsb.dev/environment"
-	"pkg.dsb.dev/storage/postgres"
+	"pkg.dsb.dev/storage/database/postgres"
 	"pkg.dsb.dev/testutil"
 )
 

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -11,7 +11,7 @@ import (
 	"github.com/rs/xid"
 	"github.com/stretchr/testify/assert"
 
-	"pkg.dsb.dev/storage/postgres"
+	"pkg.dsb.dev/storage/database/postgres"
 )
 
 // WithPostgresInstance is a test helper function that creates a connection to a postgres
@@ -41,7 +41,7 @@ func WithPostgresInstance(t *testing.T) *sql.DB {
 
 	url := fmt.Sprintf("postgres://%s:%s@%s:%s/postgres?sslmode=disable", pgUser, pgPass, pgHost, pgPort)
 
-	db, err := postgres.Open(url)
+	db, err := postgres.Open(url, nil)
 	if err != nil {
 		assert.FailNow(t, err.Error())
 		return nil
@@ -53,7 +53,7 @@ func WithPostgresInstance(t *testing.T) *sql.DB {
 	assert.NoError(t, db.Close())
 
 	url = fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", pgUser, pgPass, pgHost, pgPort, dbName)
-	db, err = postgres.Open(url)
+	db, err = postgres.Open(url, nil)
 	if err != nil {
 		assert.FailNow(t, err.Error())
 		return nil

--- a/vendor/github.com/golang-migrate/migrate/v4/source/file/README.md
+++ b/vendor/github.com/golang-migrate/migrate/v4/source/file/README.md
@@ -1,0 +1,4 @@
+# file
+
+`file:///absolute/path`  
+`file://relative/path`

--- a/vendor/github.com/golang-migrate/migrate/v4/source/file/file.go
+++ b/vendor/github.com/golang-migrate/migrate/v4/source/file/file.go
@@ -1,0 +1,61 @@
+package file
+
+import (
+	"net/http"
+	nurl "net/url"
+	"os"
+	"path/filepath"
+
+	"github.com/golang-migrate/migrate/v4/source"
+	"github.com/golang-migrate/migrate/v4/source/httpfs"
+)
+
+func init() {
+	source.Register("file", &File{})
+}
+
+type File struct {
+	httpfs.PartialDriver
+	url  string
+	path string
+}
+
+func (f *File) Open(url string) (source.Driver, error) {
+	u, err := nurl.Parse(url)
+	if err != nil {
+		return nil, err
+	}
+
+	// concat host and path to restore full path
+	// host might be `.`
+	p := u.Opaque
+	if len(p) == 0 {
+		p = u.Host + u.Path
+	}
+
+	if len(p) == 0 {
+		// default to current directory if no path
+		wd, err := os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+		p = wd
+
+	} else if p[0:1] == "." || p[0:1] != "/" {
+		// make path absolute if relative
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			return nil, err
+		}
+		p = abs
+	}
+
+	nf := &File{
+		url:  url,
+		path: p,
+	}
+	if err := nf.Init(http.Dir(p), ""); err != nil {
+		return nil, err
+	}
+	return nf, nil
+}

--- a/vendor/github.com/golang-migrate/migrate/v4/source/go_bindata/README.md
+++ b/vendor/github.com/golang-migrate/migrate/v4/source/go_bindata/README.md
@@ -1,0 +1,43 @@
+# go_bindata
+
+## Usage
+
+
+
+### Read bindata with NewWithSourceInstance
+
+```shell
+go get -u github.com/jteeuwen/go-bindata/...
+cd examples/migrations && go-bindata -pkg migrations .
+```
+
+```go
+import (
+  "github.com/golang-migrate/migrate/v4"
+  "github.com/golang-migrate/migrate/v4/source/go_bindata"
+  "github.com/golang-migrate/migrate/v4/source/go_bindata/examples/migrations"
+)
+
+func main() {
+  // wrap assets into Resource
+  s := bindata.Resource(migrations.AssetNames(),
+    func(name string) ([]byte, error) {
+      return migrations.Asset(name)
+    })
+    
+  d, err := bindata.WithInstance(s)
+  m, err := migrate.NewWithSourceInstance("go-bindata", d, "database://foobar")
+  m.Up() // run your migrations and handle the errors above of course
+}
+```
+
+### Read bindata with URL (todo)
+
+This will restore the assets in a tmp directory and then
+proxy to source/file. go-bindata must be in your `$PATH`.
+
+```
+migrate -source go-bindata://examples/migrations/bindata.go
+```
+
+

--- a/vendor/github.com/golang-migrate/migrate/v4/source/go_bindata/go-bindata.go
+++ b/vendor/github.com/golang-migrate/migrate/v4/source/go_bindata/go-bindata.go
@@ -1,0 +1,119 @@
+package bindata
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/golang-migrate/migrate/v4/source"
+)
+
+type AssetFunc func(name string) ([]byte, error)
+
+func Resource(names []string, afn AssetFunc) *AssetSource {
+	return &AssetSource{
+		Names:     names,
+		AssetFunc: afn,
+	}
+}
+
+type AssetSource struct {
+	Names     []string
+	AssetFunc AssetFunc
+}
+
+func init() {
+	source.Register("go-bindata", &Bindata{})
+}
+
+type Bindata struct {
+	path        string
+	assetSource *AssetSource
+	migrations  *source.Migrations
+}
+
+func (b *Bindata) Open(url string) (source.Driver, error) {
+	return nil, fmt.Errorf("not yet implemented")
+}
+
+var (
+	ErrNoAssetSource = fmt.Errorf("expects *AssetSource")
+)
+
+func WithInstance(instance interface{}) (source.Driver, error) {
+	if _, ok := instance.(*AssetSource); !ok {
+		return nil, ErrNoAssetSource
+	}
+	as := instance.(*AssetSource)
+
+	bn := &Bindata{
+		path:        "<go-bindata>",
+		assetSource: as,
+		migrations:  source.NewMigrations(),
+	}
+
+	for _, fi := range as.Names {
+		m, err := source.DefaultParse(fi)
+		if err != nil {
+			continue // ignore files that we can't parse
+		}
+
+		if !bn.migrations.Append(m) {
+			return nil, fmt.Errorf("unable to parse file %v", fi)
+		}
+	}
+
+	return bn, nil
+}
+
+func (b *Bindata) Close() error {
+	return nil
+}
+
+func (b *Bindata) First() (version uint, err error) {
+	if v, ok := b.migrations.First(); !ok {
+		return 0, &os.PathError{Op: "first", Path: b.path, Err: os.ErrNotExist}
+	} else {
+		return v, nil
+	}
+}
+
+func (b *Bindata) Prev(version uint) (prevVersion uint, err error) {
+	if v, ok := b.migrations.Prev(version); !ok {
+		return 0, &os.PathError{Op: fmt.Sprintf("prev for version %v", version), Path: b.path, Err: os.ErrNotExist}
+	} else {
+		return v, nil
+	}
+}
+
+func (b *Bindata) Next(version uint) (nextVersion uint, err error) {
+	if v, ok := b.migrations.Next(version); !ok {
+		return 0, &os.PathError{Op: fmt.Sprintf("next for version %v", version), Path: b.path, Err: os.ErrNotExist}
+	} else {
+		return v, nil
+	}
+}
+
+func (b *Bindata) ReadUp(version uint) (r io.ReadCloser, identifier string, err error) {
+	if m, ok := b.migrations.Up(version); ok {
+		body, err := b.assetSource.AssetFunc(m.Raw)
+		if err != nil {
+			return nil, "", err
+		}
+		return ioutil.NopCloser(bytes.NewReader(body)), m.Identifier, nil
+	}
+	return nil, "", &os.PathError{Op: fmt.Sprintf("read version %v", version), Path: b.path, Err: os.ErrNotExist}
+}
+
+func (b *Bindata) ReadDown(version uint) (r io.ReadCloser, identifier string, err error) {
+	if m, ok := b.migrations.Down(version); ok {
+		body, err := b.assetSource.AssetFunc(m.Raw)
+		if err != nil {
+			return nil, "", err
+		}
+		return ioutil.NopCloser(bytes.NewReader(body)), m.Identifier, nil
+	}
+	return nil, "", &os.PathError{Op: fmt.Sprintf("read version %v", version), Path: b.path, Err: os.ErrNotExist}
+}

--- a/vendor/github.com/golang-migrate/migrate/v4/source/httpfs/README.md
+++ b/vendor/github.com/golang-migrate/migrate/v4/source/httpfs/README.md
@@ -1,0 +1,49 @@
+# httpfs
+
+## Usage
+
+This package could be used to create new migration source drivers that uses
+`http.FileSystem` to read migration files.
+
+Struct `httpfs.PartialDriver` partly implements the `source.Driver` interface. It has all
+the methods except for `Open()`. Embedding this struct and adding `Open()` method
+allows users of this package to create new migration sources. Example:
+
+```go
+struct mydriver {
+        httpfs.PartialDriver
+}
+
+func (d *mydriver) Open(url string) (source.Driver, error) {
+	var fs http.FileSystem
+	var path string
+	var ds mydriver
+
+	// acquire fs and path from url
+	// set-up ds if necessary
+
+	if err := ds.Init(fs, path); err != nil {
+		return nil, err
+	}
+	return &ds, nil
+}
+```
+
+This package also provides a simple `source.Driver` implementation that works
+with `http.FileSystem` provided by the user of this package. It is created with
+`httpfs.New()` call.
+
+Example of using `http.Dir()` to read migrations from `sql` directory:
+
+```go
+	src, err := httpfs.New(http.Dir("sql")
+	if err != nil {
+		// do something
+	}
+	m, err := migrate.NewWithSourceInstance("httpfs", src, "database://url")
+	if err != nil {
+		// do something
+	}
+        err = m.Up()
+	...
+```

--- a/vendor/github.com/golang-migrate/migrate/v4/source/httpfs/driver.go
+++ b/vendor/github.com/golang-migrate/migrate/v4/source/httpfs/driver.go
@@ -1,0 +1,31 @@
+package httpfs
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/golang-migrate/migrate/v4/source"
+)
+
+// driver is a migration source driver for reading migrations from
+// http.FileSystem instances. It implements source.Driver interface and can be
+// used as a migration source for the main migrate library.
+type driver struct {
+	PartialDriver
+}
+
+// New creates a new migrate source driver from a http.FileSystem instance and a
+// relative path to migration files within the virtual FS.
+func New(fs http.FileSystem, path string) (source.Driver, error) {
+	var d driver
+	if err := d.Init(fs, path); err != nil {
+		return nil, err
+	}
+	return &d, nil
+}
+
+// Open completes the implementetion of source.Driver interface. Other methods
+// are implemented by the embedded PartialDriver struct.
+func (d *driver) Open(url string) (source.Driver, error) {
+	return nil, errors.New("Open() cannot be called on the httpfs passthrough driver")
+}

--- a/vendor/github.com/golang-migrate/migrate/v4/source/httpfs/partial_driver.go
+++ b/vendor/github.com/golang-migrate/migrate/v4/source/httpfs/partial_driver.go
@@ -1,0 +1,138 @@
+package httpfs
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"strconv"
+
+	"github.com/golang-migrate/migrate/v4/source"
+)
+
+// PartialDriver is a helper service for creating new source drivers working with
+// http.FileSystem instances. It implements all source.Driver interface methods
+// except for Open(). New driver could embed this struct and add missing Open()
+// method.
+//
+// To prepare PartialDriver for use Init() function.
+type PartialDriver struct {
+	migrations *source.Migrations
+	fs         http.FileSystem
+	path       string
+}
+
+// Init prepares not initialized PartialDriver instance to read migrations from a
+// http.FileSystem instance and a relative path.
+func (p *PartialDriver) Init(fs http.FileSystem, path string) error {
+	root, err := fs.Open(path)
+	if err != nil {
+		return err
+	}
+
+	files, err := root.Readdir(0)
+	if err != nil {
+		_ = root.Close()
+		return err
+	}
+	if err = root.Close(); err != nil {
+		return err
+	}
+
+	ms := source.NewMigrations()
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		m, err := source.DefaultParse(file.Name())
+		if err != nil {
+			continue // ignore files that we can't parse
+		}
+
+		if !ms.Append(m) {
+			return source.ErrDuplicateMigration{
+				Migration: *m,
+				FileInfo:  file,
+			}
+		}
+	}
+
+	p.fs = fs
+	p.path = path
+	p.migrations = ms
+	return nil
+}
+
+// Close is part of source.Driver interface implementation. This is a no-op.
+func (p *PartialDriver) Close() error {
+	return nil
+}
+
+// First is part of source.Driver interface implementation.
+func (p *PartialDriver) First() (version uint, err error) {
+	if version, ok := p.migrations.First(); ok {
+		return version, nil
+	}
+	return 0, &os.PathError{
+		Op:   "first",
+		Path: p.path,
+		Err:  os.ErrNotExist,
+	}
+}
+
+// Prev is part of source.Driver interface implementation.
+func (p *PartialDriver) Prev(version uint) (prevVersion uint, err error) {
+	if version, ok := p.migrations.Prev(version); ok {
+		return version, nil
+	}
+	return 0, &os.PathError{
+		Op:   "prev for version " + strconv.FormatUint(uint64(version), 10),
+		Path: p.path,
+		Err:  os.ErrNotExist,
+	}
+}
+
+// Next is part of source.Driver interface implementation.
+func (p *PartialDriver) Next(version uint) (nextVersion uint, err error) {
+	if version, ok := p.migrations.Next(version); ok {
+		return version, nil
+	}
+	return 0, &os.PathError{
+		Op:   "next for version " + strconv.FormatUint(uint64(version), 10),
+		Path: p.path,
+		Err:  os.ErrNotExist,
+	}
+}
+
+// ReadUp is part of source.Driver interface implementation.
+func (p *PartialDriver) ReadUp(version uint) (r io.ReadCloser, identifier string, err error) {
+	if m, ok := p.migrations.Up(version); ok {
+		body, err := p.fs.Open(path.Join(p.path, m.Raw))
+		if err != nil {
+			return nil, "", err
+		}
+		return body, m.Identifier, nil
+	}
+	return nil, "", &os.PathError{
+		Op:   "read up for version " + strconv.FormatUint(uint64(version), 10),
+		Path: p.path,
+		Err:  os.ErrNotExist,
+	}
+}
+
+// ReadDown is part of source.Driver interface implementation.
+func (p *PartialDriver) ReadDown(version uint) (r io.ReadCloser, identifier string, err error) {
+	if m, ok := p.migrations.Down(version); ok {
+		body, err := p.fs.Open(path.Join(p.path, m.Raw))
+		if err != nil {
+			return nil, "", err
+		}
+		return body, m.Identifier, nil
+	}
+	return nil, "", &os.PathError{
+		Op:   "read down for version " + strconv.FormatUint(uint64(version), 10),
+		Path: p.path,
+		Err:  os.ErrNotExist,
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -136,6 +136,9 @@ github.com/golang-migrate/migrate/v4/database
 github.com/golang-migrate/migrate/v4/database/postgres
 github.com/golang-migrate/migrate/v4/internal/url
 github.com/golang-migrate/migrate/v4/source
+github.com/golang-migrate/migrate/v4/source/file
+github.com/golang-migrate/migrate/v4/source/go_bindata
+github.com/golang-migrate/migrate/v4/source/httpfs
 # github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
 github.com/golang/groupcache/lru
 # github.com/golang/mock v1.4.4


### PR DESCRIPTION
Breaking change for postgres support, moves package from storage/postgres to
storage/database/postgres. Allows users to supply golang-migrate style migration
scripts when opening connections to the postgres database.