### PR TITLE
Move request id logic out of middleware

### DIFF
--- a/middleware/request_id.go
+++ b/middleware/request_id.go
@@ -3,9 +3,7 @@ package middleware
 import (
 	"net/http"
 
-	"github.com/gofrs/uuid"
 	"github.com/gorilla/mux"
-	"github.com/opentracing/opentracing-go"
 
 	"pkg.dsb.dev/requestid"
 )
@@ -13,21 +11,9 @@ import (
 // RequestID is a middleware that reuses or creates a request id for each HTTP request. The
 // id is also added to the request context using the requestid package.
 func RequestID() mux.MiddlewareFunc {
-	const key = "X-Request-ID"
 	return func(handler http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			id := r.Header.Get(key)
-			if id == "" {
-				id = uuid.Must(uuid.NewV4()).String()
-				r.Header.Set(key, id)
-			}
-
-			if span := opentracing.SpanFromContext(r.Context()); span != nil {
-				span.SetTag("http.request_id", id)
-			}
-
-			ctx := requestid.ToContext(r.Context(), id)
-			w.Header().Set(key, id)
+			ctx := requestid.Extract(r.Context(), r.Header, w.Header())
 			handler.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}

--- a/requestid/requestid.go
+++ b/requestid/requestid.go
@@ -2,11 +2,37 @@
 // context.Context.
 package requestid
 
-import "context"
+import (
+	"context"
+	"net/http"
+
+	"github.com/gofrs/uuid"
+	"github.com/opentracing/opentracing-go"
+)
 
 type (
 	ctxKey struct{}
 )
+
+// Extract the request id from the X-Request-ID header from 'in'. If it does not exist, it is
+// generated as a V4 UUID. The X-Request-ID is then set on 'out'. The returned context contains
+// the request id and if tracing is enabled the request id is added to the current span.
+func Extract(ctx context.Context, in, out http.Header) context.Context {
+	const key = "X-Request-ID"
+
+	id := in.Get(key)
+	if id == "" {
+		id = uuid.Must(uuid.NewV4()).String()
+		in.Set(key, id)
+	}
+
+	out.Set(key, id)
+	if span := opentracing.SpanFromContext(ctx); span != nil {
+		span.SetTag("http.request_id", id)
+	}
+
+	return ToContext(ctx, id)
+}
 
 // ToContext adds a request id to a context.
 func ToContext(ctx context.Context, id string) context.Context {

--- a/requestid/requestid_test.go
+++ b/requestid/requestid_test.go
@@ -1,0 +1,44 @@
+package requestid_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"pkg.dsb.dev/requestid"
+)
+
+func TestExtract(t *testing.T) {
+	t.Parallel()
+	const key = "X-Request-ID"
+
+	tt := []struct {
+		Name          string
+		RequestHeader http.Header
+	}{
+		{
+			Name: "It should use an existing request id",
+			RequestHeader: map[string][]string{
+				key: {"test-id"},
+			},
+		},
+		{
+			Name:          "It should generate an identifier",
+			RequestHeader: make(http.Header),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			ctx := context.Background()
+			respHeader := make(http.Header)
+			ctx = requestid.Extract(ctx, tc.RequestHeader, respHeader)
+
+			assert.NotEmpty(t, tc.RequestHeader.Get(key))
+			assert.NotEmpty(t, respHeader.Get(key))
+			assert.EqualValues(t, tc.RequestHeader.Get(key), respHeader.Get(key))
+		})
+	}
+}


### PR DESCRIPTION
The `requestid` package was somewhat useless on its own, this moves the main logic
for generating/propagating request identifiers into a requestid.Extract method and
simplifies the middleware.