### PR TITLE
pkg/retry: Create retry package

### DIFF
--- a/cron/cron.go
+++ b/cron/cron.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 
+	"pkg.dsb.dev/retry"
 	"pkg.dsb.dev/tracing"
 )
 
@@ -14,6 +15,8 @@ type (
 	// The Action type is a function that is invoked by a cron.
 	Action func(context.Context) error
 )
+
+const retryMax = 3
 
 // Every invokes 'fn' every time the 'freq' duration passes. This will continue until the provided context
 // is cancelled, or 'fn' returns an error.
@@ -27,7 +30,7 @@ func Every(ctx context.Context, freq time.Duration, fn Action) error {
 		case <-ticker.C:
 			span, ctx := opentracing.StartSpanFromContext(ctx, "cron-run")
 			span.SetTag("cron.frequency", freq)
-			if err := fn(ctx); err != nil {
+			if err := retry.Do(ctx, retryMax, fn); err != nil {
 				span.Finish()
 				return tracing.WithError(span, err)
 			}
@@ -58,7 +61,7 @@ func At(ctx context.Context, at time.Time, fn Action) error {
 
 			span, ctx := opentracing.StartSpanFromContext(ctx, "cron-run")
 			span.SetTag("cron.at", at)
-			if err := fn(ctx); err != nil {
+			if err := retry.Do(ctx, retryMax, fn); err != nil {
 				span.Finish()
 				return tracing.WithError(span, err)
 			}

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -1,0 +1,26 @@
+// Package retry contains utilities for performing retries when functions return errors.
+package retry
+
+import "context"
+
+// Do performs an action with a maximum number of retries. If fn returns a non-nil error, it will
+// be retried up to the maximum number of times and then returned. If fn returns a nil error, the retry
+// loop is broken. The loop is also broken if the provided context is cancelled.
+func Do(ctx context.Context, max int, fn func(ctx context.Context) error) error {
+	var err error
+
+retry:
+	for i := 0; i < max; i++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			err = fn(ctx)
+			if err == nil {
+				break retry
+			}
+		}
+	}
+
+	return err
+}

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -1,0 +1,35 @@
+package retry_test
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"pkg.dsb.dev/retry"
+)
+
+func TestDo(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// Test no error only invokes once
+	invoked := 0
+	assert.NoError(t, retry.Do(ctx, 3, func(_ context.Context) error {
+		invoked++
+		return nil
+	}))
+
+	assert.EqualValues(t, 1, invoked)
+
+	// Test error invokes the maximum times before returning
+	invoked = 0
+	assert.Error(t, retry.Do(ctx, 3, func(_ context.Context) error {
+		invoked++
+		return io.EOF
+	}))
+
+	assert.EqualValues(t, 3, invoked)
+}


### PR DESCRIPTION
Adds a retry package for performing functions multiple times if they return
an error. Updates the cron package to always try up to 3 times before
returning.