### PR TITLE
database/badger: Use default options and expose a few changable ones

### DIFF
--- a/server/grpc.go
+++ b/server/grpc.go
@@ -47,6 +47,7 @@ func ServeGRPC(ctx context.Context, opts ...GRPCOption) error {
 
 	grp, ctx := errgroup.WithContext(ctx)
 	grp.Go(func() error {
+		logging.WithField("port", ":5000").Info("serving gRPC")
 		return svr.Serve(lis)
 	})
 	grp.Go(func() error {

--- a/storage/database/badger/badger.go
+++ b/storage/database/badger/badger.go
@@ -30,15 +30,25 @@ type (
 	}
 )
 
-// Open a badger database using the provided options.
-func Open(options badger.Options) (*DB, error) {
-	inner, err := badger.Open(options)
+// Open a badger database using the provided options. Uses badger.DefaultOptions
+// storing data in a "badger" directory and disabling logging.
+func Open(opts ...Option) (*DB, error) {
+	// Default directory is named "badger" and logging is
+	// disabled.
+	c := badger.DefaultOptions("badger")
+	c.Logger = nil
+
+	for _, opt := range opts {
+		opt(&c)
+	}
+
+	inner, err := badger.Open(c)
 	if err != nil {
 		return nil, err
 	}
 
 	db := &DB{inner: inner}
-	health.AddCheck(options.Dir, db.Ping)
+	health.AddCheck(c.Dir, db.Ping)
 	return db, nil
 }
 

--- a/storage/database/badger/badger_test.go
+++ b/storage/database/badger/badger_test.go
@@ -5,14 +5,13 @@ import (
 	"os"
 	"testing"
 
-	bdg "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 
 	"pkg.dsb.dev/storage/database/badger"
 )
 
 func TestOpen(t *testing.T) {
-	db, err := badger.Open(bdg.DefaultOptions("test"))
+	db, err := badger.Open(badger.WithDir("test"))
 	assert.NoError(t, err)
 	assert.NotNil(t, db)
 	t.Cleanup(func() {

--- a/storage/database/badger/options.go
+++ b/storage/database/badger/options.go
@@ -1,0 +1,43 @@
+package badger
+
+import (
+	"time"
+
+	"github.com/dgraph-io/badger/v2"
+)
+
+type (
+	// The Option type is a function that modifies the badger configuration.
+	Option func(opts *badger.Options)
+)
+
+// WithDir sets the location on disk badger will write data.
+func WithDir(dir string) Option {
+	return func(opts *badger.Options) {
+		opts.Dir = dir
+		opts.ValueDir = dir
+	}
+}
+
+// WithEncryptionKey sets the key to use to encrypt data at rest on the
+// filesystem.
+func WithEncryptionKey(key []byte) Option {
+	return func(opts *badger.Options) {
+		opts.EncryptionKey = key
+	}
+}
+
+// WithEncryptionKeyRotationDuration sets how often to change the generated
+// encryption key.
+func WithEncryptionKeyRotationDuration(dur time.Duration) Option {
+	return func(opts *badger.Options) {
+		opts.EncryptionKeyRotationDuration = dur
+	}
+}
+
+// WithLogger sets the logger that badger will use when writing logs.
+func WithLogger(logger badger.Logger) Option {
+	return func(opts *badger.Options) {
+		opts.Logger = logger
+	}
+}


### PR DESCRIPTION
I don't really every need any more than the default options. This changes the package
to always use the default but allows changing encryption key, directory and logging.