### PR TITLE
pkg/logger: Expose global logger

### DIFF
--- a/logging/logger.go
+++ b/logging/logger.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
+	"github.com/uber/jaeger-client-go"
 )
 
 var level string
@@ -34,4 +35,25 @@ func WithField(k string, v interface{}) *logrus.Entry {
 // Info writes an info level log.
 func Info(args ...interface{}) {
 	logrus.Info(args...)
+}
+
+// Logger returns the global logger.
+func Logger() *logrus.Logger {
+	return logrus.StandardLogger()
+}
+
+type (
+	jaegerLogger struct {
+		*logrus.Logger
+	}
+)
+
+// JaegerLogger returns the standard logger as an implementation of jaeger.Logger.
+func JaegerLogger() jaeger.Logger {
+	return &jaegerLogger{Logger: Logger()}
+}
+
+// Error writes an error message to the log.
+func (l *jaegerLogger) Error(msg string) {
+	l.Logger.Error(msg)
 }

--- a/storage/database/badger/badger.go
+++ b/storage/database/badger/badger.go
@@ -8,6 +8,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 
 	"pkg.dsb.dev/health"
+	"pkg.dsb.dev/logging"
 	"pkg.dsb.dev/tracing"
 )
 
@@ -31,12 +32,12 @@ type (
 )
 
 // Open a badger database using the provided options. Uses badger.DefaultOptions
-// storing data in a "badger" directory and disabling logging.
+// storing data in a "badger" directory.
 func Open(opts ...Option) (*DB, error) {
 	// Default directory is named "badger" and logging is
 	// disabled.
 	c := badger.DefaultOptions("badger")
-	c.Logger = nil
+	c.Logger = logging.Logger()
 
 	for _, opt := range opts {
 		opt(&c)

--- a/storage/database/badger/options.go
+++ b/storage/database/badger/options.go
@@ -34,10 +34,3 @@ func WithEncryptionKeyRotationDuration(dur time.Duration) Option {
 		opts.EncryptionKeyRotationDuration = dur
 	}
 }
-
-// WithLogger sets the logger that badger will use when writing logs.
-func WithLogger(logger badger.Logger) Option {
-	return func(opts *badger.Options) {
-		opts.Logger = logger
-	}
-}

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -16,6 +16,7 @@ import (
 
 	"pkg.dsb.dev/closers"
 	"pkg.dsb.dev/environment"
+	"pkg.dsb.dev/logging"
 )
 
 type (
@@ -51,6 +52,7 @@ func New() (io.Closer, error) {
 		jaeger.NewRemoteReporter(
 			sender,
 			jaeger.ReporterOptions.BufferFlushInterval(config.bufferFlushInterval),
+			jaeger.ReporterOptions.Logger(logging.JaegerLogger()),
 		),
 	)
 


### PR DESCRIPTION
Exposes the global logger using `Logger` method. Creates a wrapper so the global logger
can be used with tracing & badger