### PR TITLE
pkg/tracing: Set tracer logger

### DIFF
--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -54,6 +54,7 @@ func New() (io.Closer, error) {
 			jaeger.ReporterOptions.BufferFlushInterval(config.bufferFlushInterval),
 			jaeger.ReporterOptions.Logger(logging.JaegerLogger()),
 		),
+		jaeger.TracerOptions.Logger(logging.JaegerLogger()),
 	)
 
 	opentracing.SetGlobalTracer(tracer)


### PR DESCRIPTION
Set the tracer logger to the one provided in the `logging` package