### PR TITLE
pkg/app: Create wrapper package for cli flags

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,3 +25,5 @@ issues:
   exclude-use-default: false
   exclude:
     - G102
+    - G304
+    - G204

--- a/app/app.go
+++ b/app/app.go
@@ -16,6 +16,7 @@ import (
 
 	"pkg.dsb.dev/closers"
 	"pkg.dsb.dev/environment"
+	"pkg.dsb.dev/flag"
 	"pkg.dsb.dev/health"
 	"pkg.dsb.dev/logging"
 	"pkg.dsb.dev/metrics"
@@ -115,14 +116,17 @@ func WithRunner(run RunFunc) Option {
 }
 
 // WithFlags sets command-line flags that can be applied before Run is called.
-func WithFlags(flags ...cli.Flag) Option {
+func WithFlags(flags ...flag.Flag) Option {
 	return func(app *cli.App) {
-		app.Flags = flags
-		app.Flags = append(app.Flags, tracing.Flags...)
-		app.Flags = append(app.Flags, monitoring.Flags...)
-		app.Flags = append(app.Flags, health.Flags...)
-		app.Flags = append(app.Flags, metrics.Flags...)
-		app.Flags = append(app.Flags, logging.Flags...)
+		for _, fl := range flags {
+			app.Flags = append(app.Flags, fl.Unwrap())
+		}
+
+		app.Flags = append(app.Flags, tracing.Flags.Unwrap()...)
+		app.Flags = append(app.Flags, monitoring.Flags.Unwrap()...)
+		app.Flags = append(app.Flags, health.Flags.Unwrap()...)
+		app.Flags = append(app.Flags, metrics.Flags.Unwrap()...)
+		app.Flags = append(app.Flags, logging.Flags.Unwrap()...)
 
 		sort.Sort(cli.FlagsByName(app.Flags))
 	}

--- a/flag/flags.go
+++ b/flag/flags.go
@@ -1,0 +1,136 @@
+// Package flag contains types that represent typed command-line flags.
+package flag
+
+import (
+	"time"
+
+	"github.com/urfave/cli/v2"
+)
+
+type (
+	// The Flag interface describes types that can be unwrapped into a cli.Flag
+	// implementation.
+	Flag interface {
+		Unwrap() cli.Flag
+	}
+
+	// The Flags type is a collection of Flag implementations.
+	Flags []Flag
+)
+
+// Unwrap all flags in the collection to their cli.Flag equivalents.
+func (f Flags) Unwrap() []cli.Flag {
+	out := make([]cli.Flag, len(f))
+	for i, flag := range f {
+		out[i] = flag.Unwrap()
+	}
+	return out
+}
+
+// The String type represents a command-line flag that is parsed as a string value.
+type String struct {
+	Name        string
+	Usage       string
+	Value       string
+	Destination *string
+	EnvVar      string
+	Required    bool
+}
+
+// Unwrap the String into its cli.Flag equivalent.
+func (f *String) Unwrap() cli.Flag {
+	fl := &cli.StringFlag{
+		Name:        f.Name,
+		Usage:       f.Usage,
+		Value:       f.Value,
+		Destination: f.Destination,
+		Required:    f.Required,
+	}
+
+	if f.EnvVar != "" {
+		fl.EnvVars = []string{f.EnvVar}
+	}
+
+	return fl
+}
+
+// The Boolean type represents a command-line flag that is parsed as a boolean value.
+type Boolean struct {
+	Value       bool
+	Required    bool
+	Destination *bool
+	Name        string
+	Usage       string
+	EnvVar      string
+}
+
+// Unwrap the Boolean into its cli.Flag equivalent.
+func (f *Boolean) Unwrap() cli.Flag {
+	fl := &cli.BoolFlag{
+		Name:        f.Name,
+		Usage:       f.Usage,
+		Value:       f.Value,
+		Destination: f.Destination,
+		Required:    f.Required,
+	}
+
+	if f.EnvVar != "" {
+		fl.EnvVars = []string{f.EnvVar}
+	}
+
+	return fl
+}
+
+// The Float64 type represents a command-line flag that is parsed as a float64 value.
+type Float64 struct {
+	Name        string
+	Usage       string
+	Value       float64
+	Destination *float64
+	EnvVar      string
+	Required    bool
+}
+
+// Unwrap the Float64 into its cli.Flag equivalent.
+func (f *Float64) Unwrap() cli.Flag {
+	fl := &cli.Float64Flag{
+		Name:        f.Name,
+		Usage:       f.Usage,
+		Value:       f.Value,
+		Destination: f.Destination,
+		Required:    f.Required,
+	}
+
+	if f.EnvVar != "" {
+		fl.EnvVars = []string{f.EnvVar}
+	}
+
+	return fl
+}
+
+// The Duration type represents a command-line flag that is parsed as a time.Duration value.
+type Duration struct {
+	Name        string
+	Usage       string
+	Value       time.Duration
+	Destination *time.Duration
+	EnvVar      string
+	Required    bool
+}
+
+// Unwrap the Duration into its cli.Flag equivalent.
+func (f *Duration) Unwrap() cli.Flag {
+	fl := &cli.DurationFlag{
+		Name:        f.Name,
+		Usage:       f.Usage,
+		Value:       f.Value,
+		Destination: f.Destination,
+		Required:    f.Required,
+	}
+
+	if f.EnvVar != "" {
+		fl.EnvVars = []string{f.EnvVar}
+	}
+
+	return fl
+}

--- a/health/flags.go
+++ b/health/flags.go
@@ -1,13 +1,15 @@
 package health
 
-import "github.com/urfave/cli/v2"
+import (
+	"pkg.dsb.dev/flag"
+)
 
 // Flags contains all command-line flags that can be used to configure health checks.
-var Flags = []cli.Flag{
-	&cli.BoolFlag{
+var Flags = flag.Flags{
+	&flag.Boolean{
 		Name:        "health-check-disabled",
 		Usage:       "Disables the health check endpoint",
-		EnvVars:     []string{"HEALTH_CHECK_DISABLED"},
+		EnvVar:      "HEALTH_CHECK_DISABLED",
 		Destination: &disabled,
 	},
 }

--- a/logging/flags.go
+++ b/logging/flags.go
@@ -1,14 +1,15 @@
 package logging
 
-import "github.com/urfave/cli/v2"
+import (
+	"pkg.dsb.dev/flag"
+)
 
 // Flags contains all command-line flags used by the logger.
-var Flags = []cli.Flag{
-	&cli.StringFlag{
+var Flags = flag.Flags{
+	&flag.String{
 		Name:        "log-level",
-		Aliases:     nil,
 		Usage:       "Sets the verbosity of logs (panic, fatal, error, warn, info, debug & trace)",
-		EnvVars:     []string{"LOG_LEVEL"},
+		EnvVar:      "LOG_LEVEL",
 		Value:       "error",
 		Destination: &level,
 	},

--- a/metrics/flags.go
+++ b/metrics/flags.go
@@ -1,19 +1,21 @@
 package metrics
 
-import "github.com/urfave/cli/v2"
+import (
+	"pkg.dsb.dev/flag"
+)
 
 // Flags contains all command-line flags that can be used to configure metrics.
-var Flags = []cli.Flag{
-	&cli.BoolFlag{
+var Flags = flag.Flags{
+	&flag.Boolean{
 		Name:        "metrics-disabled",
 		Usage:       "Disables exporting prometheus metrics",
-		EnvVars:     []string{"METRICS_DISABLED"},
+		EnvVar:      "METRICS_DISABLED",
 		Destination: &disabled,
 	},
-	&cli.StringFlag{
+	&flag.String{
 		Name:        "metrics-push-url",
 		Usage:       "URL of the prometheus push gateway, if set, metrics are pushed",
-		EnvVars:     []string{"METRICS_PUSH_URL"},
+		EnvVar:      "METRICS_PUSH_URL",
 		Destination: &pushURL,
 	},
 }

--- a/monitoring/flags.go
+++ b/monitoring/flags.go
@@ -1,26 +1,28 @@
 package monitoring
 
-import "github.com/urfave/cli/v2"
+import (
+	"pkg.dsb.dev/flag"
+)
 
 // Flags contains all command-line flags that can be used to configure monitoring.
-var Flags = []cli.Flag{
-	&cli.BoolFlag{
+var Flags = flag.Flags{
+	&flag.Boolean{
 		Name:        "monitoring-disabled",
 		Usage:       "Disables application monitoring",
-		EnvVars:     []string{"MONITORING_DISABLED"},
+		EnvVar:      "MONITORING_DISABLED",
 		Destination: &config.disabled,
 	},
-	&cli.StringFlag{
+	&flag.String{
 		Name:        "monitoring-environment",
 		Usage:       "Environment to use when writing to application monitoring",
-		EnvVars:     []string{"MONITORING_ENVIRONMENT"},
+		EnvVar:      "MONITORING_ENVIRONMENT",
 		Destination: &config.environment,
 		Value:       "development",
 	},
-	&cli.StringFlag{
+	&flag.String{
 		Name:        "monitoring-dsn",
 		Usage:       "DSN to use for sending reports to sentry",
-		EnvVars:     []string{"MONITORING_DSN"},
+		EnvVar:      "MONITORING_DSN",
 		Destination: &config.dsn,
 	},
 }

--- a/tracing/flags.go
+++ b/tracing/flags.go
@@ -3,35 +3,35 @@ package tracing
 import (
 	"time"
 
-	"github.com/urfave/cli/v2"
+	"pkg.dsb.dev/flag"
 )
 
 // Flags contains all command-line flags that can be used to configure tracing.
-var Flags = []cli.Flag{
-	&cli.BoolFlag{
+var Flags = flag.Flags{
+	&flag.Boolean{
 		Name:        "tracer-disabled",
 		Usage:       "If true, disables opentracing",
-		EnvVars:     []string{"TRACER_DISABLED"},
+		EnvVar:      "TRACER_DISABLED",
 		Destination: &config.disabled,
 	},
-	&cli.StringFlag{
+	&flag.String{
 		Name:        "tracer-host",
 		Usage:       "Host for opentracing",
-		EnvVars:     []string{"TRACER_HOST"},
+		EnvVar:      "TRACER_HOST",
 		Value:       "jaeger:6831",
 		Destination: &config.host,
 	},
-	&cli.Float64Flag{
+	&flag.Float64{
 		Name:        "tracer-sample-rate",
 		Usage:       "Sample rate for traces",
-		EnvVars:     []string{"TRACER_SAMPLE_RATE"},
+		EnvVar:      "TRACER_SAMPLE_RATE",
 		Value:       1,
 		Destination: &config.sampleRate,
 	},
-	&cli.DurationFlag{
+	&flag.Duration{
 		Name:        "tracer-flush-interval",
 		Usage:       "Buffer flushing interval for traces",
-		EnvVars:     []string{"TRACER_BUFFER_FLUSH_INTERVAL"},
+		EnvVar:      "TRACER_BUFFER_FLUSH_INTERVAL",
 		Value:       time.Second,
 		Destination: &config.bufferFlushInterval,
 	},


### PR DESCRIPTION
Creats a `flag` package that contains flag implementations for hiding the underlying flag implementation from users.

Currently supports:

* `Boolean`
* `Float64`
* `String`
* `Duration`