### PR TITLE
pkg/closers: Add CloseFunc

### DIFF
--- a/closers/closers.go
+++ b/closers/closers.go
@@ -8,6 +8,10 @@ import (
 
 type (
 	noopCloser struct{}
+
+	functionCloser struct {
+		fn func() error
+	}
 )
 
 // Noop is an io.Closer implementation that does nothing.
@@ -23,4 +27,15 @@ func Close(c io.Closer) {
 // Close does nothing.
 func (nc *noopCloser) Close() error {
 	return nil
+}
+
+// CloseFunc wraps te provider function as an io.Closer implementation. This can be used when you
+// have a type that has some form of close method that does not directly implement io.Closer.
+func CloseFunc(fn func() error) io.Closer {
+	return &functionCloser{fn: fn}
+}
+
+// Close calls the desired function.
+func (c *functionCloser) Close() error {
+	return c.fn()
 }

--- a/closers/closers_test.go
+++ b/closers/closers_test.go
@@ -22,8 +22,23 @@ func (c *NoopCloser) Close() error {
 }
 
 func TestClose(t *testing.T) {
+	t.Parallel()
+
 	c := &NoopCloser{err: io.EOF}
 
 	closers.Close(c)
 	assert.True(t, c.closed)
+}
+
+func TestCloseFunc(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	c := closers.CloseFunc(func() error {
+		called = true
+		return nil
+	})
+
+	closers.Close(c)
+	assert.True(t, called)
 }


### PR DESCRIPTION
Adds a `CloseFunc` method that returns an `io.Closer` implementation that calls a desired function. This can be
used in scenarios where you have a type that requires some form of closing but does not implement `io.Closer`
directly. For example, the elasticsearch `BulkIndexer` has a `Close(context.Context)` method.