### PR TITLE
pkg/server: Add DialGRPC function

### DIFF
--- a/server/grpc.go
+++ b/server/grpc.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"net"
 
+	grpc_opentracing "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
+	grpc_validator "github.com/grpc-ecosystem/go-grpc-middleware/validator"
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 
@@ -69,4 +72,19 @@ func ServeGRPC(ctx context.Context, opts ...GRPCOption) error {
 	default:
 		return nil
 	}
+}
+
+// DialGRPC connects to a desired gRPC server, applying default options and registering interceptors.
+func DialGRPC(ctx context.Context, addr string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	return grpc.DialContext(ctx, addr, append(opts,
+		grpc.WithBlock(),
+		grpc.WithChainUnaryInterceptor(
+			grpc_opentracing.UnaryClientInterceptor(),
+			grpc_prometheus.UnaryClientInterceptor,
+			grpc_validator.UnaryClientInterceptor(),
+		),
+		grpc.WithChainStreamInterceptor(
+			grpc_opentracing.StreamClientInterceptor(),
+			grpc_prometheus.StreamClientInterceptor,
+		))...)
 }

--- a/server/grpc_test.go
+++ b/server/grpc_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
 
 	"pkg.dsb.dev/server"
 )
@@ -30,4 +31,19 @@ func TestServeGRPC(t *testing.T) {
 	case <-ticker.C:
 		assert.Fail(t, "server did not shut down after 10 seconds")
 	}
+}
+
+func TestDialGRPC(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		assert.NoError(t, server.ServeGRPC(ctx))
+	}()
+
+	conn, err := server.DialGRPC(ctx, "localhost:5000", grpc.WithInsecure())
+	assert.NoError(t, err)
+	assert.NotNil(t, conn)
+
+	assert.NoError(t, conn.Close())
+	cancel()
 }


### PR DESCRIPTION
Adds `server.DialGRPC` that creates a `grpc.ClientConn` and adds all the usual client unary/stream interceptors.