### PR TITLE
pkg/server: Don't use package-level variable for default options

### DIFF
--- a/server/grpc.go
+++ b/server/grpc.go
@@ -32,7 +32,7 @@ type (
 // ServeGRPC starts a gRPC server listening on port 5000 configured using the provided options. This function
 // blocks until the provided context is cancelled. On cancellation, the server is gracefully stopped.
 func ServeGRPC(ctx context.Context, opts ...GRPCOption) error {
-	c := defaultGRPCConfig
+	c := defaultGRPCConfig()
 	for _, opt := range opts {
 		opt(&c)
 	}

--- a/server/grpc_options.go
+++ b/server/grpc_options.go
@@ -24,29 +24,31 @@ const (
 	defaultTime                  = 5 * time.Minute
 )
 
-var defaultGRPCConfig = grpcConfig{
-	serverOptions: []grpc.ServerOption{
-		grpc.ChainUnaryInterceptor(
-			grpc_opentracing.UnaryServerInterceptor(),
-			grpc_prometheus.UnaryServerInterceptor,
-			grpc_recovery.UnaryServerInterceptor(),
-			grpc_validator.UnaryServerInterceptor(),
-			grpc_ctxtags.UnaryServerInterceptor(),
-		),
-		grpc.ChainStreamInterceptor(
-			grpc_opentracing.StreamServerInterceptor(),
-			grpc_prometheus.StreamServerInterceptor,
-			grpc_recovery.StreamServerInterceptor(),
-			grpc_validator.StreamServerInterceptor(),
-			grpc_ctxtags.StreamServerInterceptor(),
-		),
-		grpc.KeepaliveParams(keepalive.ServerParameters{
-			MaxConnectionIdle:     defaultMaxConnectionIdle,
-			MaxConnectionAge:      defaultMaxConnectionAge,
-			MaxConnectionAgeGrace: defaultMaxConnectionAgeGrace,
-			Time:                  defaultTime,
-		}),
-	},
+func defaultGRPCConfig() grpcConfig {
+	return grpcConfig{
+		serverOptions: []grpc.ServerOption{
+			grpc.ChainUnaryInterceptor(
+				grpc_opentracing.UnaryServerInterceptor(),
+				grpc_prometheus.UnaryServerInterceptor,
+				grpc_recovery.UnaryServerInterceptor(),
+				grpc_validator.UnaryServerInterceptor(),
+				grpc_ctxtags.UnaryServerInterceptor(),
+			),
+			grpc.ChainStreamInterceptor(
+				grpc_opentracing.StreamServerInterceptor(),
+				grpc_prometheus.StreamServerInterceptor,
+				grpc_recovery.StreamServerInterceptor(),
+				grpc_validator.StreamServerInterceptor(),
+				grpc_ctxtags.StreamServerInterceptor(),
+			),
+			grpc.KeepaliveParams(keepalive.ServerParameters{
+				MaxConnectionIdle:     defaultMaxConnectionIdle,
+				MaxConnectionAge:      defaultMaxConnectionAge,
+				MaxConnectionAgeGrace: defaultMaxConnectionAgeGrace,
+				Time:                  defaultTime,
+			}),
+		},
+	}
 }
 
 // WithServerOptions configures the options to use when calling grpc.NewServer.


### PR DESCRIPTION
This fixes a bug causing tracing for gRPC to not work correctly, as when the `var` is instantiated, `tracing.New` has not
been called, so the global tracer is unset. This makes sure that we always get the options as late as possible so the global
tracer is set correctly.