### PR TITLE
storage/blob: Ensure blob.bytes_read is set

### DIFF
--- a/storage/blob/bucket.go
+++ b/storage/blob/bucket.go
@@ -262,6 +262,7 @@ func (r *Reader) Read(p []byte) (int, error) {
 		return n, tracing.WithError(r.span, err)
 	default:
 		r.n += n
+		r.span.SetTag("blob.bytes_read", r.n)
 		return n, nil
 	}
 }


### PR DESCRIPTION
Looks like this isn't being set in all scenarios, so update the value on each call to read.