### PR TITLE
pkg/closers: Add CloseAll and MultiCloser

### DIFF
--- a/closers/closers.go
+++ b/closers/closers.go
@@ -3,7 +3,9 @@ package closers
 
 import (
 	"io"
-	"log"
+
+	"pkg.dsb.dev/logging"
+	"pkg.dsb.dev/multierror"
 )
 
 type (
@@ -12,6 +14,10 @@ type (
 	functionCloser struct {
 		fn func() error
 	}
+
+	// The MultiCloser type is a collection of io.Closer implementations that can be collected
+	// and closed at once.
+	MultiCloser []io.Closer
 )
 
 // Noop is an io.Closer implementation that does nothing.
@@ -20,7 +26,14 @@ var Noop io.Closer = &noopCloser{}
 // Close the given closer. If a non-nil error is returned, it is logged.
 func Close(c io.Closer) {
 	if err := c.Close(); err != nil {
-		log.Println(err.Error())
+		logging.WithError(err).Error("failed to close")
+	}
+}
+
+// CloseAll calls Close on all io.Closer implementations passed as arguments.
+func CloseAll(cs ...io.Closer) {
+	for _, c := range cs {
+		Close(c)
 	}
 }
 
@@ -38,4 +51,20 @@ func CloseFunc(fn func() error) io.Closer {
 // Close calls the desired function.
 func (c *functionCloser) Close() error {
 	return c.fn()
+}
+
+// Add a closer to the MultiCloser. It will be closed when calling MultiCloser.Close.
+func (c *MultiCloser) Add(cl io.Closer) {
+	*c = append(*c, cl)
+}
+
+// Close all io.Closer implementations in the MultiCloser. Returns any non-nil errors as a
+// multi-error.
+func (c *MultiCloser) Close() error {
+	errs := make([]error, len(*c))
+	for i, closer := range *c {
+		errs[i] = closer.Close()
+	}
+
+	return multierror.Append(nil, errs...)
 }

--- a/closers/closers_test.go
+++ b/closers/closers_test.go
@@ -42,3 +42,35 @@ func TestCloseFunc(t *testing.T) {
 	closers.Close(c)
 	assert.True(t, called)
 }
+
+func TestCloseAll(t *testing.T) {
+	t.Parallel()
+
+	cs := make([]io.Closer, 100)
+	noops := make([]*NoopCloser, 100)
+	for i := 0; i < 100; i++ {
+		noops[i] = &NoopCloser{}
+		cs[i] = noops[i]
+	}
+
+	closers.CloseAll(cs...)
+	for _, c := range noops {
+		assert.True(t, c.closed)
+	}
+}
+
+func TestMultiCloser_Close(t *testing.T) {
+	t.Parallel()
+
+	mc := closers.MultiCloser{}
+	noops := make([]*NoopCloser, 100)
+	for i := 0; i < 100; i++ {
+		noops[i] = &NoopCloser{}
+		mc.Add(noops[i])
+	}
+
+	assert.NoError(t, mc.Close())
+	for _, c := range noops {
+		assert.True(t, c.closed)
+	}
+}


### PR DESCRIPTION
Adds `closers.CloseAll` to close a provided variadic number of `io.Closer` implementations.
Adds `MultiCloser` type to act as a collection of `io.Closer` implementations that can all be closed at once.