### PR TITLE
pkg/event: Add tracer information to event metadata

### DIFF
--- a/event/reader_test.go
+++ b/event/reader_test.go
@@ -3,30 +3,83 @@ package event_test
 import (
 	"context"
 	"errors"
+	"log"
+	"os"
 	"testing"
+	"time"
 
+	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/uber/jaeger-client-go"
 
 	"pkg.dsb.dev/closers"
 	"pkg.dsb.dev/event"
 )
 
-func TestReader_Read(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	wr, err := event.NewWriter(ctx, "mem://test-topic")
-	assert.NoError(t, err)
+var (
+	wr *event.Writer
+	rd *event.Reader
+)
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	var err error
+
+	wr, err = event.NewWriter(ctx, "mem://test-topic")
+	if err != nil {
+		log.Fatal(err)
+	}
 	defer closers.Close(wr)
 
-	rd, err := event.NewReader(ctx, "mem://test-topic")
-	assert.NoError(t, err)
+	rd, err = event.NewReader(ctx, "mem://test-topic")
+	if err != nil {
+		log.Fatal(err)
+	}
 	defer closers.Close(rd)
+
+	os.Exit(m.Run())
+}
+
+func TestReader_Read(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
 
 	assert.NoError(t, wr.Write(ctx, event.Event{
 		Payload: []byte("hello world"),
 	}))
 
-	err = rd.Read(ctx, func(ctx context.Context, evt event.Event) error {
+	err := rd.Read(ctx, func(ctx context.Context, evt event.Event) error {
 		assert.EqualValues(t, []byte("hello world"), evt.Payload)
+		cancel()
+		return nil
+	})
+	assert.True(t, errors.Is(err, context.Canceled))
+}
+
+func TestEventTracing(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	tracer, closer := jaeger.NewTracer(
+		"test",
+		jaeger.NewConstSampler(true),
+		jaeger.NewInMemoryReporter(),
+	)
+
+	defer closers.Close(closer)
+	opentracing.SetGlobalTracer(tracer)
+
+	assert.NoError(t, wr.Write(ctx, event.Event{
+		Payload: []byte("hello world"),
+	}))
+
+	err := rd.Read(ctx, func(ctx context.Context, evt event.Event) error {
+		span := opentracing.SpanFromContext(ctx)
+		assert.NotNil(t, span)
+
+		spanCtx := span.Context()
+		assert.NotNil(t, spanCtx)
+
 		cancel()
 		return nil
 	})

--- a/event/writer.go
+++ b/event/writer.go
@@ -38,8 +38,15 @@ func (w *Writer) Write(ctx context.Context, evt Event) error {
 
 	span.SetTag("event.topic", w.name)
 
-	err := w.topic.Send(ctx, &pubsub.Message{
-		Body: evt.Payload,
+	// Include span metadata in event metadata.
+	md, err := tracing.SpanMetadata(span)
+	if err != nil {
+		return err
+	}
+
+	err = w.topic.Send(ctx, &pubsub.Message{
+		Body:     evt.Payload,
+		Metadata: md,
 	})
 	if err != nil {
 		return tracing.WithError(span, err)


### PR DESCRIPTION
When reading/writing events, attempt to extract span identifiers and encode it in the event metadata. This enables traces
working across publishers/consumers.