### PR TITLE
Make log format configurable via flags

### DIFF
--- a/logging/flags.go
+++ b/logging/flags.go
@@ -13,4 +13,11 @@ var Flags = flag.Flags{
 		Value:       "error",
 		Destination: &level,
 	},
+	&flag.String{
+		Name:        "log-format",
+		Usage:       "Sets the desired log formatter (text, json)",
+		EnvVar:      "LOG_FORMAT",
+		Value:       "text",
+		Destination: &format,
+	},
 }

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -8,7 +8,10 @@ import (
 	"github.com/uber/jaeger-client-go"
 )
 
-var level string
+var (
+	level  string
+	format string
+)
 
 // Init initialises the logger.
 func Init() {
@@ -18,8 +21,17 @@ func Init() {
 	}
 
 	logrus.SetLevel(lvl)
-	logrus.SetFormatter(&logrus.JSONFormatter{})
 	logrus.SetOutput(os.Stdout)
+
+	switch format {
+	default:
+		logrus.SetFormatter(&logrus.TextFormatter{})
+		WithField("format", format).Warn("unknown log format")
+	case "json":
+		logrus.SetFormatter(&logrus.JSONFormatter{})
+	case "text":
+		logrus.SetFormatter(&logrus.TextFormatter{})
+	}
 }
 
 // WithError adds an error to the log.


### PR DESCRIPTION
Introduces `log-format` flag and `LOG_FORMAT` environment variable that sets a desired
log formatter. Currently accepts `json` and `text` and defaults to `text`.