### PR TITLE
pkg/tracing: Disabled by default

### DIFF
--- a/tracing/flags.go
+++ b/tracing/flags.go
@@ -18,7 +18,6 @@ var Flags = flag.Flags{
 		Name:        "tracer-host",
 		Usage:       "Host for opentracing",
 		EnvVar:      "TRACER_HOST",
-		Value:       "jaeger:6831",
 		Destination: &config.host,
 	},
 	&flag.Float64{

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -31,7 +31,6 @@ type (
 )
 
 var config = &options{
-	host:                "jaeger:6831",
 	sampleRate:          1,
 	bufferFlushInterval: time.Second,
 }
@@ -39,7 +38,7 @@ var config = &options{
 // New sets up the global tracer. The io.Closer instance returned is
 // used to stop tracing.
 func New() (io.Closer, error) {
-	if config.disabled {
+	if config.disabled || config.host == "" {
 		return closers.Noop, nil
 	}
 


### PR DESCRIPTION
Sets up tracing to be disabled by default and to no longer use the default tracer url. It just ends up spamming
logs when you don't want to use it and don't explicitly disable it.